### PR TITLE
HW11

### DIFF
--- a/kubernetes-vault/ExternalSecret.yaml
+++ b/kubernetes-vault/ExternalSecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: otus-extsecret
+  namespace: vault
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: otus-store
+    kind: SecretStore
+  target:
+    name: otus-cred
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      key: cred

--- a/kubernetes-vault/SecretStore.yaml
+++ b/kubernetes-vault/SecretStore.yaml
@@ -1,0 +1,35 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: otus-store
+  namespace: vault
+spec:
+  retrySettings:
+    maxRetries: 5
+    retryInterval: "10s"
+  
+  provider:
+    vault:
+      server: "http://vault.vault:8200"
+      # Path is the mount path of the Vault KV backend endpoint
+      path: "otus"
+      # Version is the Vault KV secret engine version.
+      # This can be either "v1" or "v2", defaults to "v2"
+      version: "v2"
+      # vault enterprise namespace: https://www.vaultproject.io/docs/enterprise/namespaces
+      namespace: "vault"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "otus"
+          # Optional service account reference
+          serviceAccountRef:
+            name: "vault-auth"
+          # namespace: "vault"
+          # Optional secret field containing a Kubernetes ServiceAccount JWT
+          # used for authenticating with Vault
+          #secretRef:
+          #  name: "my-secret"
+          #  namespace: "secret-admin"
+          #  key: "vault"
+

--- a/kubernetes-vault/otus-policy.hcl
+++ b/kubernetes-vault/otus-policy.hcl
@@ -1,0 +1,3 @@
+path "otus/data/cred" {
+  capabilities = ["read", "list"]
+}

--- a/kubernetes-vault/serviceAccount.yaml
+++ b/kubernetes-vault/serviceAccount.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-auth
+  namespace: vault
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: vault-auth
+  name: vault-auth-token
+  namespace: vault
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vault-auth-binding
+  namespace: vault
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: vault-auth
+  namespace: vault

--- a/kubernetes-vault/values-consul.yaml
+++ b/kubernetes-vault/values-consul.yaml
@@ -1,0 +1,5 @@
+server:
+  enabled: "-"
+  logLevel: ""
+  image: null
+  replicas: 3

--- a/kubernetes-vault/values-vault.yaml
+++ b/kubernetes-vault/values-vault.yaml
@@ -1,0 +1,20 @@
+server:
+  ha:
+    enabled: true
+    replicas: 3
+   
+    config: |
+      ui = true
+
+      listener "tcp" {
+        tls_disable = 1
+        address = "[::]:8200"
+        cluster_address = "[::]:8201"
+      }
+      storage "consul" {
+        path = "vault"
+        address = "consul-server.consul:8500"
+      }
+
+      service_registration "kubernetes" {}
+


### PR DESCRIPTION
# Выполнено ДЗ №11

 - [*] Основное ДЗ

## В процессе сделано:
 - Развернут managed k8s в Yandex cloud, кол-во нод под рабочую нагрузку = 3
 - В namespace consul установите consul из helm-чарта
 - В namespace vault установите hashicorp vault из helm-чарта
 - Выполнена инициализацию vault и распечатаны с помощью полученных unseal key все поды хранилища
 - Создано хранилище секретов otus/ с Secret Engine KV, а в нем секрет otus/cred, содержащий username='otus' password='asajkjkahs'
 - В Vault включена авторизация auth/kubernetes и сконфигурирована с использованием токен и сертификата ранее созданного ServiceAccount
 - Создана и применена политика otus-policy для секретов /otus/cred
 - Создана роль auth/kubernetes/role/otus в vault с использованием ServiceAccount vault-auth из namespace Vault и политикой otus-policy
 - Установлен External Secrets Operator из helm-чарта в namespace vault
 - Создайте и примените манифест crd объекта SecretStore, а также ExternalSecret.
 
## Как запустить проект:
 - Установка consul
   git clone https://github.com/hashicorp/consul-k8s.git
   helm upgrade --install consul consul-k8s/charts/consul/ --set global.name=consul --create-namespace -n consul -f values-consul.yaml
- Установка vault
   git clone https://github.com/hashicorp/vault-helm.git
   helm install vault vault-helm/ --create-namespace -n vault -f values-vault.yaml
- Инициализация vault
  kubectl -n vault exec -it vault-0 -- vault operator init
- Распечатка всех подов хранилища
  kubectl -n vault exec -it vault-0 -- vault operator unseal key-1 (по каждому ключу на каждый под)
- Создаем хранилище и кладем креды
   kubectl -n vault exec -it vault-0 -- vault secrets enable -version=2 -path=otus kv
   kubectl -n vault exec -it vault-0 -- vault kv put otus/cred username='otus' password='asajkjkahs'
- Применяем манифест для создания сервисного аккаунта и секрета и назначения clusterrole
   kubectl apply -f serviceAccount.yaml
- Включаем авторизацию kubernetes в vault
   kubectl -n vault exec -it vault-0 -- vault auth enable kubernetes
- Сконфигурируем с использованием токена и сертификата ранее созданного ServiceAccount
    JWT=$(kubectl -n vault get secret vault-auth-token -o go-template='{{ .data.token }}' | base64 --decode)
    KUBE_CA_CERT=$(kubectl config view --raw --minify --flatten -o jsonpath='{.clusters[].cluster.certificate-authority-data}' | base64 --decode)
    KUBE_HOST=$(kubectl config view --raw --minify --flatten --output='jsonpath={.clusters[].cluster.server}')
    kubectl -n vault exec -it vault-0 -- vault write auth/kubernetes/config \
    token_reviewer_jwt="$JWT" \
    kubernetes_host="$KUBE_HOST" \
    kubernetes_ca_cert="$KUBE_CA_CERT" \
    disable_local_ca_jwt="true"
- Применим политику в Vault
   cat otus-policy.hcl | kubectl -n vault exec -it vault-0 -- vault policy write otus-policy -
- Создадим роль
   kubectl -n vault exec -it vault-0 -- vault write auth/kubernetes/role/otus \
        bound_service_account_names=vault-auth \
        bound_service_account_namespaces=vault \
        policies=otus-policy \
        ttl=24h
- Установим External Secrets Operator
  helm repo add external-secrets https://charts.external-secrets.io/
  helm upgrade --install external-secrets external-secrets/external-secrets --create-namespace -n vault
- Применим манифесты
   kubectl apply -f SecretStore.yaml
   kubectl apply -f ExternalSecret.yaml
   
## Как проверить работоспособность:
 - Проверим созданный секрет otus-cred
    kubectl -n vault get secret otus-cred

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
